### PR TITLE
feat: add notifications for events

### DIFF
--- a/pdudaemon/httplistener.py
+++ b/pdudaemon/httplistener.py
@@ -23,6 +23,9 @@ import pdudaemon.listener as listener
 
 from aiohttp import web
 
+from .listener import EventCollector
+
+
 logger = logging.getLogger('pdud.http')
 
 
@@ -38,8 +41,10 @@ class HTTPListener:
             web.get('/power/control/on', self.handle),
             web.get('/power/control/off', self.handle),
             web.get('/power/control/reboot', self.handle),
+            web.get('/power/control/subscribe', self.handle),
         ])
         self.apprunner = None
+        self.event_collector = EventCollector()
 
     async def start(self):
         logger.info("Starting the HTTP server")
@@ -52,6 +57,9 @@ class HTTPListener:
         logger.info("Listening on %s:%s", listen_host, listen_port)
 
     async def shutdown(self):
+        if self.event_collector:
+            await self.event_collector.cleanup()
+        self.event_collector = None
         if self.apprunner:
             await self.apprunner.cleanup()
         self.apprunner = None
@@ -60,14 +68,16 @@ class HTTPListener:
         logger.info("Handling HTTP request from %s: %s", request.remote, request.path_qs)
         data = urlparse.parse_qs(urlparse.urlparse(request.path_qs).query)
         path = urlparse.urlparse(request.path_qs).path
-        res = await self.insert_request(data, path)
+        res = await self.insert_request(data, path, request)
         if res:
             return web.Response(status=200, text="OK - accepted request\n")
         else:
             return web.Response(status=500, text="Invalid request\n")
 
-    async def insert_request(self, data, path):
+    async def insert_request(self, data, path, request):
         args = listener.parse_http(data, path)
         if args:
-            return await listener.process_request(args, self.config, self.daemon)
+            return await listener.process_request(
+                args, self.config, self.daemon, request, self.event_collector
+            )
 

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -18,8 +18,57 @@
 #  MA 02110-1301, USA.
 
 import asyncio
+import collections
+import contextlib
+import enum
+import json
 import logging
+
+import aiohttp.web
+
+
+# for example nginx's "proxy_read_timeout" defaults to 60 seconds
+POLLING_KEEPALIVE_PERIOD_SECONDS = 50
+
+
 logger = logging.getLogger('pdud.listener')
+
+
+class PortEvent(collections.namedtuple("PortEvent", ("port", "state"))):
+
+    def serialize(self):
+        return {
+            "port": str(self.port),
+            "is_powered": self.state == PortState.ON,
+        }
+
+
+class PortState(enum.Enum):
+    ON = "on"
+    OFF = "off"
+
+
+class EventCollector:
+
+    def __init__(self):
+        self._listener_queues = []
+
+    @contextlib.contextmanager
+    def get_listener(self) -> asyncio.Queue:
+        listener_queue = asyncio.Queue()
+        self._listener_queues.append(listener_queue)
+        try:
+            yield listener_queue
+        finally:
+            self._listener_queues.remove(listener_queue)
+
+    async def notify(self, port_event: PortEvent) -> None:
+        for queue in list(self._listener_queues):
+            await queue.put(port_event)
+
+    async def cleanup(self):
+        # listeners are supposed to treat a None as a signal for stopping
+        await self.notify(None)
 
 
 class Args(object):
@@ -65,7 +114,7 @@ def parse_http(data, path):
     return args
 
 
-async def process_request(args, config, daemon):
+async def process_request(args, config, daemon, request, event_collector: EventCollector):
     if args.request in ["on", "off"] and args.delay is not None:
         logger.warn("delay parameter is deprecated for on/off commands")
     if args.delay is not None:
@@ -77,6 +126,26 @@ async def process_request(args, config, daemon):
             args.delay = 5
         else:
             args.delay = 0
+    if args.request == "subscribe":
+        response = aiohttp.web.StreamResponse()
+        await response.prepare(request)
+        with event_collector.get_listener() as listener:
+            while True:
+                try:
+                    event = await asyncio.wait_for(
+                        listener.get(), timeout=POLLING_KEEPALIVE_PERIOD_SECONDS
+                    )
+                except asyncio.TimeoutError:
+                    # We should send a bit of data from time to time in order to prevent
+                    # proxy servers from killing our connection.
+                    data = {}
+                else:
+                    if event is None:
+                        # the collector signals, that we should stop listening
+                        break
+                    data = event.serialize()
+                await response.write(json.dumps(data).encode() + b'\n')
+        await response.write_eof()
     if args.alias:
         if args.hostname or args.port:
             logging.error("Trying to use and alias and also a hostname/port")
@@ -100,11 +169,15 @@ async def process_request(args, config, daemon):
     runner = daemon.runners[args.hostname]
     if args.request == "reboot":
         logger.debug("reboot requested, submitting off/on")
+
+        await event_collector.notify(PortEvent(int(args.port), PortState.OFF))
         await runner.do_job_async(int(args.port), "off")
         await asyncio.sleep(int(args.delay))
+        await event_collector.notify(PortEvent(int(args.port), PortState.ON))
         await runner.do_job_async(int(args.port), "on")
         return True
     else:
         await asyncio.sleep(int(args.delay))
+        await event_collector.notify(PortEvent(int(args.port), PortState.ON if args.request == "on" else PortState.OFF))
         await runner.do_job_async(int(args.port), args.request)
         return True

--- a/pdudaemon/tcplistener.py
+++ b/pdudaemon/tcplistener.py
@@ -59,14 +59,16 @@ class TCPListener:
 
     async def handle(self, reader, writer):
         request_ip = writer.get_extra_info('peername')[0]
+        loop = asyncio.get_running_loop()
         try:
             data = await reader.read(16384)
             data = data.decode('utf-8')
             data = data.strip()
-            socket.setdefaulttimeout(2)
             try:
-                request_host = socket.gethostbyaddr(request_ip)[0]
-            except socket.herror:
+                request_host = await asyncio.wait_for(
+                        loop.run_in_executor(None, socket.gethostbyaddr, request_ip),
+                        timeout=2)[0]
+            except (socket.herror, asyncio.TimeoutError):
                 request_host = request_ip
             logger.info("Received a request from %s: '%s'", request_host, data)
             res = await self.insert_request(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 pexpect
 requests
 systemd_python

--- a/share/pdudaemon-test.sh
+++ b/share/pdudaemon-test.sh
@@ -2,10 +2,8 @@
 
 PDUD_BINARY=pdudaemon
 TMPFILE=/tmp/pdu
-DBFILE=/tmp/dbfile
 
 rm $TMPFILE
-rm $DBFILE
 
 # support the -l option for running the tests locally
 while getopts l option
@@ -25,7 +23,7 @@ then
   PDUD_BINARY=./pdudaemon-test-bin
 fi
 
-$PDUD_BINARY --loglevel=DEBUG --conf=share/pdudaemon.conf --dbfile=$DBFILE &
+$PDUD_BINARY --loglevel=DEBUG --conf=share/pdudaemon.conf &
 PDU_PID=$!
 
 sleep 3
@@ -41,7 +39,7 @@ kill $PDU_PID
 sleep 10
 
 # Test TCP listener
-$PDUD_BINARY --loglevel=DEBUG --listener tcp --conf=share/pdudaemon.conf --dbfile=$DBFILE &
+$PDUD_BINARY --loglevel=DEBUG --listener tcp --conf=share/pdudaemon.conf &
 PDU_PID=$!
 
 sleep 3

--- a/share/pdudaemon.service
+++ b/share/pdudaemon.service
@@ -2,7 +2,7 @@
 Description=Control and Queueing daemon for PDUs
 
 [Service]
-ExecStart=/usr/sbin/pdudaemon --journal --dbfile=/var/lib/pdudaemon/pdudaemon.db --conf=/etc/pdudaemon/pdudaemon.conf
+ExecStart=/usr/sbin/pdudaemon --journal --conf=/etc/pdudaemon/pdudaemon.conf
 Type=simple
 DynamicUser=yes
 StateDirectory=pdudaemon

--- a/share/supervisord.conf
+++ b/share/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:pdudaemon]
-command=/usr/local/bin/pdudaemon --dbfile=/config/pdudaemon.db --conf=/config/pdudaemon.conf
+command=/usr/local/bin/pdudaemon --conf=/config/pdudaemon.conf
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Listener stores on/off events in a queue and notifies subscribers about new events by using long living HTTP requests.

This is something I need to keep my web front end up to date. Maybe someone else can make use of this feature as well.
I would be happy to discuss whether or not this should be part of `pdudaemon` and will gladly address any issues you might have with my code. Thanks!